### PR TITLE
Admin user lists (pending/approved/rejected) + admin seeder profile fix

### DIFF
--- a/src/PpmV2.Api/Controllers/AdminUsersController.cs
+++ b/src/PpmV2.Api/Controllers/AdminUsersController.cs
@@ -28,6 +28,20 @@ public class AdminUsersController : ControllerBase
         return Ok(pendingUsers);
     }
 
+    [HttpGet("approved")]
+    public async Task<IActionResult> GetApprovedUsers()
+    {
+        var approvedUsers = await _adminUserService.GetApprovedUsersAsync();
+        return Ok(approvedUsers);
+    }
+
+    [HttpGet("rejected")]
+    public async Task<IActionResult> GetRejectedUsers()
+    {
+        var rejectedUsers = await _adminUserService.GetRejectedUsersAsync();
+        return Ok(rejectedUsers);
+    }
+
     [HttpPut("approve/{id:guid}")]
     public async Task<IActionResult> Approve(Guid id)
     {

--- a/src/PpmV2.Api/Program.cs
+++ b/src/PpmV2.Api/Program.cs
@@ -126,10 +126,11 @@ using (var scope = app.Services.CreateScope())
     var services = scope.ServiceProvider;
 
     var userManager = services.GetRequiredService<UserManager<AppUser>>();
+    var dbContext = scope.ServiceProvider.GetRequiredService<AppDbContext>();
     var configuration = services.GetRequiredService<IConfiguration>();
     var logger = services.GetRequiredService<ILoggerFactory>().CreateLogger("AdminSeeder");
 
-    await AdminSeeder.SeedAsync(userManager, configuration, logger);
+    await AdminSeeder.SeedAsync(userManager, dbContext, configuration, logger);
 }
 
 


### PR DESCRIPTION
## Zusammenfassung
- Admin-Endpunkte zum Auflisten von Benutzern nach Status (Pending, Approved, Rejected) hinzugefügt
- Einheitliches `UserAdminListDto` für Admin-Benutzerlisten eingeführt
- Bereinigung von Legacy-Daten (Default-Rollen)
- Admin-Seeder angepasst, sodass immer ein vollständiges Admin-Profil erstellt wird

## Scope
- Keine Breaking Changes
- Der Role-Assignment-Endpunkt (`PUT /api/admin/users/{id}/role`) ist **nicht** Teil dieses Pull Requests und wird in einem **Folge-PR innerhalb desselben Issues/Milestones** umgesetzt

## Verifikation
- Admin-Listen-Endpunkte manuell über Insomnia getestet
- Konsistenz der Datenbank nach Datenbereinigung überprüft
