### PR TITLE
docs: Kommentare und Dokumentation für Architecture-Boundaries (Auth/Admin/Shifts/Persistence/API)

### DIFF
--- a/src/PpmV2.Api/Common/ApiProblem.cs
+++ b/src/PpmV2.Api/Common/ApiProblem.cs
@@ -3,8 +3,20 @@ using PpmV2.Application.Common.Errors;
 
 namespace PpmV2.Api.Common;
 
+/// <summary>
+/// Factory for standardized ProblemDetails responses.
+/// </summary>
+/// <remarks>
+/// Converts application-level errors (AppError) into RFC 7807 ProblemDetails.
+/// This keeps controllers thin and ensures consistent error responses across endpoints.
+/// </remarks>
 public static class ApiProblem
 {
+    /// <summary>
+    /// Creates an ObjectResult containing ProblemDetails based on the given AppError.
+    /// </summary>
+    /// <param name="error">Application error containing HTTP status, error code, message and optional field errors.</param>
+    /// <param name="http">Current HTTP context (used for ProblemDetails.Instance).</param>
     public static ObjectResult From(AppError error, HttpContext http)
     {
         var pd = new ProblemDetails
@@ -15,6 +27,7 @@ public static class ApiProblem
             Instance = http.Request.Path
         };
 
+        // Optional field-level errors (e.g. validation errors) are exposed via extensions.
         if (error.Errors is not null && error.Errors.Count > 0)
             pd.Extensions["errors"] = error.Errors;
 

--- a/src/PpmV2.Api/Controllers/AdminUsersController.cs
+++ b/src/PpmV2.Api/Controllers/AdminUsersController.cs
@@ -11,6 +11,13 @@ namespace PpmV2.Api.Controllers;
 [ApiController]
 [Route("api/admin/users")]
 [Authorize(Policy = "AdminOnly")]
+/// <summary>
+/// Admin-only endpoints to manage user approval and role assignment.
+/// </summary>
+/// <remarks>
+/// This controller is protected by the "AdminOnly" authorization policy.
+/// It delegates all business logic to the application service (IAdminUserService).
+/// </remarks>
 public class AdminUsersController : ControllerBase
 {
 
@@ -50,7 +57,8 @@ public class AdminUsersController : ControllerBase
 
         if (!result.Success)
         {
-            // string.Equals(result.ErrorMessage, "User not found.", StringComparison.OrdinalIgnoreCase)
+            // Note: This controller currently returns simple message responses.
+            // TODO : Unifying error responses with ProblemDetails (ApiProblem) in a future cleanup PR.
             if (result.ErrorMessage == "User not found")
                 return NotFound(new { message = result.ErrorMessage });
             

--- a/src/PpmV2.Api/Controllers/AuthController.cs
+++ b/src/PpmV2.Api/Controllers/AuthController.cs
@@ -7,6 +7,14 @@ namespace PpmV2.Api.Controllers;
 
 [ApiController]
 [Route("api/[controller]")]
+/// <summary>
+/// Public authentication endpoints (register/login).
+/// </summary>
+/// <remarks>
+/// This controller acts as a thin HTTP boundary:
+/// - delegates all authentication logic to the application/infrastructure service
+/// - converts domain/application errors into ProblemDetails via ApiProblem
+/// </remarks>
 public class AuthController : ControllerBase
 {
     private readonly IAuthService _auth;
@@ -18,9 +26,11 @@ public class AuthController : ControllerBase
     {
         var result = await _auth.RegisterAsync(request);
 
+        // Standardized error response mapping (ProblemDetails) for failed auth results.
         if (!result.Success)
             return ApiProblem.From(result.ToAppError(), HttpContext);
 
+        // Registration does not return a token (approval workflow).
         return Ok(new
         {
             userId = result.UserId,

--- a/src/PpmV2.Api/Middleware/ExceptionHandlingMiddleware.cs
+++ b/src/PpmV2.Api/Middleware/ExceptionHandlingMiddleware.cs
@@ -4,6 +4,13 @@ using PpmV2.Application.Common.Exceptions;
 
 namespace PpmV2.Api.Middleware;
 
+/// <summary>
+/// Central exception-to-ProblemDetails middleware.
+/// </summary>
+/// <remarks>
+/// This middleware translates known application exceptions into standardized RFC 7807 responses.
+/// Currently it handles ValidationException and returns HTTP 400 with field-level error details.
+/// </remarks>
 public sealed class ExceptionHandlingMiddleware
 {
     private readonly RequestDelegate _next;
@@ -18,6 +25,7 @@ public sealed class ExceptionHandlingMiddleware
         }
         catch (ValidationException ex)
         {
+            // Validation errors are returned as ProblemDetails (application/problem+json).
             context.Response.StatusCode = (int)HttpStatusCode.BadRequest;
             context.Response.ContentType = "application/problem+json";
 
@@ -28,6 +36,7 @@ public sealed class ExceptionHandlingMiddleware
                 Detail = ex.Message
             };
 
+            // Attach field-level validation details in extensions to support client-side error rendering.
             if (ex.Errors.Count > 0)
                 problem.Extensions["errors"] = ex.Errors;
 

--- a/src/PpmV2.Application/Common/Errors/AppError.cs
+++ b/src/PpmV2.Application/Common/Errors/AppError.cs
@@ -1,6 +1,15 @@
 ﻿namespace PpmV2.Application.Common.Errors;
 
-
+/// <summary>
+/// Represents a structured application error independent of HTTP or transport concerns.
+/// </summary>
+/// <remarks>
+/// AppError is used to transport error information from the application layer
+/// to the API layer, where it is mapped to RFC 7807 ProblemDetails.
+/// 
+/// It supports both a general error message and optional field-level errors
+/// (e.g. validation errors).
+/// </remarks>
 public sealed record AppError(
     string Code,
     string Message,

--- a/src/PpmV2.Application/Common/Exceptions/ValidationException.cs
+++ b/src/PpmV2.Application/Common/Exceptions/ValidationException.cs
@@ -1,5 +1,12 @@
 ﻿namespace PpmV2.Application.Common.Exceptions;
 
+/// <summary>
+/// Exception type representing validation failures in application use cases.
+/// </summary>
+/// <remarks>
+/// This exception is thrown when business or input validation rules are violated.
+/// It is translated into a standardized ProblemDetails response by the API middleware.
+/// </remarks>
 public sealed class ValidationException : Exception
 {
     public string Code { get; }

--- a/src/PpmV2.Application/Common/Results/ServiceResult.cs
+++ b/src/PpmV2.Application/Common/Results/ServiceResult.cs
@@ -1,9 +1,14 @@
-﻿using System;
-using System.Collections.Generic;
-using System.Text;
+﻿namespace PpmV2.Application.Common.Results;
 
-namespace PpmV2.Application.Common.Results;
-
+/// <summary>
+/// Represents the result of an application service operation.
+/// </summary>
+/// <remarks>
+/// ServiceResult is used for non-exceptional control flow where failures are expected
+/// and should be handled explicitly (e.g. user not found, invalid credentials).
+/// 
+/// This avoids using exceptions for regular business outcomes.
+/// </remarks>
 public class ServiceResult
 {
     public bool Success { get; }

--- a/src/PpmV2.Application/Common/Results/ServiceResultT.cs
+++ b/src/PpmV2.Application/Common/Results/ServiceResultT.cs
@@ -1,9 +1,12 @@
-﻿using System;
-using System.Collections.Generic;
-using System.Text;
+﻿namespace PpmV2.Application.Common.Results;
 
-namespace PpmV2.Application.Common.Results;
-
+/// <summary>
+/// Generic version of ServiceResult carrying a data payload on success.
+/// </summary>
+/// <remarks>
+/// This type is commonly used by application services to return data together
+/// with success/failure information without throwing exceptions.
+/// </remarks>
 public class ServiceResult<T> : ServiceResult
 {
     public T? Data { get; }

--- a/src/PpmV2.Application/Shifts/Commands/Creation/CreateShiftCommand.cs
+++ b/src/PpmV2.Application/Shifts/Commands/Creation/CreateShiftCommand.cs
@@ -1,5 +1,12 @@
 ﻿namespace PpmV2.Application.Shifts.Commands.Creation;
 
+/// <summary>
+/// Command representing the "Create Shift" use case.
+/// </summary>
+/// <remarks>
+/// This command is the application-layer representation of the create intent.
+/// API request DTOs are mapped to this command before execution.
+/// </remarks>
 public sealed record CreateShiftCommand(
     string Title,
     string? Description,

--- a/src/PpmV2.Application/Shifts/Commands/Creation/CreateShiftParticipantDto.cs
+++ b/src/PpmV2.Application/Shifts/Commands/Creation/CreateShiftParticipantDto.cs
@@ -2,4 +2,10 @@
 
 namespace PpmV2.Application.Shifts.Commands.Creation;
 
+/// <summary>
+/// Internal participant DTO used by the CreateShift command.
+/// </summary>
+/// <remarks>
+/// This type represents validated/normalized data used inside the application use case.
+/// It is distinct from API request models to keep external contracts decoupled from internal processing.
 public sealed record CreateShiftParticipantDto(Guid UserId, ShiftRole Role);

--- a/src/PpmV2.Application/Shifts/DTOs/CreateShiftRequest.cs
+++ b/src/PpmV2.Application/Shifts/DTOs/CreateShiftRequest.cs
@@ -1,5 +1,12 @@
 ﻿namespace PpmV2.Application.Shifts.DTOs;
 
+/// <summary>
+/// Client request model for creating a Shift.
+/// </summary>
+/// <remarks>
+/// This is an API-facing input DTO (untrusted input).
+/// It should be mapped to CreateShiftCommand after validation/normalization.
+/// </remarks>
 public sealed class CreateShiftRequest
 {
     public string Title { get; set; } = default!;

--- a/src/PpmV2.Application/Shifts/DTOs/ShiftDetailsDto.cs
+++ b/src/PpmV2.Application/Shifts/DTOs/ShiftDetailsDto.cs
@@ -1,6 +1,15 @@
 ﻿using PpmV2.Domain.Shifts;
 
 namespace PpmV2.Application.Shifts.DTOs;
+
+/// <summary>
+/// Read model for displaying shift details (UI/API output).
+/// </summary>
+/// <remarks>
+/// This DTO is optimized for read scenarios and may contain computed fields.
+/// In particular, Readiness and MissingRequirements indicate whether business prerequisites
+/// for certain actions (e.g. publish) are satisfied.
+/// </remarks>
 public class ShiftDetailsDto
 {
     public Guid Id { get; set; }
@@ -13,7 +22,15 @@ public class ShiftDetailsDto
     public ShiftLocationDto Location { get; set; } = default!;
     public List<ShiftParticipantDto> Participants { get; set; } = new();
 
+    /// <summary>
+    /// Computed readiness indicator (e.g. "ready" / "not_ready") used by the UI flow.
+    /// </summary>
     public string Readiness { get; set; } = default!;
+
+    /// <summary>
+    /// List of missing prerequisites (keys) when the shift is not ready.
+    /// Example keys: "leader", "festmitarbeiter".
+    /// </summary>
     public List<string> MissingRequirements { get; set; } = new();
 
 }

--- a/src/PpmV2.Application/Shifts/Interfaces/ICurrentUser.cs
+++ b/src/PpmV2.Application/Shifts/Interfaces/ICurrentUser.cs
@@ -1,7 +1,16 @@
 ﻿namespace PpmV2.Application.Shifts.Interfaces;
 
+/// <summary>
+/// Abstraction for accessing information about the currently authenticated user.
+/// </summary>
+/// <remarks>
+/// The application layer depends on this interface to avoid direct coupling to ASP.NET Core.
+/// The Infrastructure/API layer provides the concrete implementation based on HttpContext claims.
+/// </remarks>
 public interface ICurrentUser
 {
     Guid UserId { get; }
-    bool IsInRole(string role); // optional
+
+    // Returns whether the current user is in the given role.
+    bool IsInRole(string role);
 }

--- a/src/PpmV2.Application/Shifts/Interfaces/IShiftDetailsQuery.cs
+++ b/src/PpmV2.Application/Shifts/Interfaces/IShiftDetailsQuery.cs
@@ -2,7 +2,15 @@
 
 namespace PpmV2.Application.Shifts.Interfaces;
 
+/// <summary>
+/// Read-side query port for shift details.
+/// </summary>
+/// <remarks>
+/// This interface represents the CQRS read model boundary.
+/// Implementations should return DTO projections (read models) and avoid exposing EF Core entities.
+/// </remarks>
 public interface IShiftDetailsQuery
 {
+    /// <summary>Returns a detailed read model for the given shift(Einsatz) id or null if not found.</summary>
     Task<ShiftDetailsDto?> GetByIdAsync(Guid einsatzId, CancellationToken ct);
 }

--- a/src/PpmV2.Application/Shifts/Interfaces/IShiftRepository.cs
+++ b/src/PpmV2.Application/Shifts/Interfaces/IShiftRepository.cs
@@ -2,15 +2,36 @@
 
 namespace PpmV2.Application.Shifts.Interfaces;
 
+/// <summary>
+/// Write-side persistence port for Shift aggregates.
+/// </summary>
+/// <remarks>
+/// The application layer depends on this abstraction.
+/// Infrastructure provides the EF Core implementation.
+/// 
+/// This interface currently focuses on the create flow (Draft creation + participants).
+/// Additional write operations (publish/complete/member changes) can be added as the feature evolves.
+/// </remarks>
 public interface IShiftRepository
 {
+    /// <summary>Checks whether the referenced Location exists.</summary>
     Task<bool> LocationExistsAsync(Guid locationId, CancellationToken ct);
+
+    /// <summary>
+    /// Counts how many of the given user ids exist in the Identity store.
+    /// Used for defensive validation before persistence.
+    /// </summary>
     Task<int> CountExistingUsersAsync(IReadOnlyCollection<Guid> userIds, CancellationToken ct);
 
+    /// <summary>
+    /// Adds the shift aggregate and its participants to the current unit of work.
+    /// Call SaveChangesAsync to persist.
+    /// </summary>
     Task AddAsync(
         Shift einsatz,
         IReadOnlyCollection<ShiftParticipant> participants,
         CancellationToken ct);
 
+    /// <summary>Persists all pending changes of the current unit of work.</summary>
     Task SaveChangesAsync(CancellationToken ct);
 }

--- a/src/PpmV2.Infrastructure/Admin/Services/AdminUserService.cs
+++ b/src/PpmV2.Infrastructure/Admin/Services/AdminUserService.cs
@@ -8,6 +8,19 @@ using PpmV2.Infrastructure.Identity;
 
 namespace PpmV2.Infrastructure.Admin.Services;
 
+/// <summary>
+/// Admin-only user management service.
+/// </summary>
+/// <remarks>
+/// This service is part of the Infrastructure layer and builds on ASP.NET Core Identity.
+/// It encapsulates administrative operations such as:
+/// - listing users by approval status
+/// - approving/rejecting users
+/// - assigning roles under strict rules
+///
+/// Failures are returned using ServiceResult to represent expected business outcomes
+/// without throwing exceptions.
+/// </remarks>
 public class AdminUserService : IAdminUserService
 {
     private readonly UserManager<AppUser> _userManager;
@@ -17,8 +30,15 @@ public class AdminUserService : IAdminUserService
         _userManager = userManager;
     }
 
+    /// <summary>Returns users whose accounts are pending approval.</summary>
     public Task<List<UserAdminListDto>> GetPendingUsersAsync() => GetUsersByStatusAsync(UserStatus.Pending);
 
+    /// <summary>
+    /// Approves a user account (Pending -> Approved).
+    /// </summary>
+    /// <remarks>
+    /// If the user is already approved, the operation is idempotent and returns success.
+    /// </remarks>
     public async Task<ServiceResult> ApproveUserAsync(Guid userId) {
         
         var user = await _userManager.FindByIdAsync(userId.ToString());
@@ -46,6 +66,12 @@ public class AdminUserService : IAdminUserService
         return ServiceResult.Ok();
     }
 
+    /// <summary>
+    /// Rejects a user account (Pending -> Rejected).
+    /// </summary>
+    /// <remarks>
+    /// If the user is already rejected, the operation is idempotent and returns success.
+    /// </remarks>
     public async Task<ServiceResult> RejectUserAsync(Guid userId) { 
     
         var user = await _userManager.FindByIdAsync(userId.ToString());
@@ -89,7 +115,15 @@ public class AdminUserService : IAdminUserService
             .ToListAsync();
     }
 
-
+    /// <summary>
+    /// Assigns a role to an approved user under strict constraints.
+    /// </summary>
+    /// <remarks>
+    /// Rules:
+    /// - role changes are allowed only for approved users
+    /// - Admin role cannot be assigned via this API endpoint
+    /// - Unknown/invalid roles are rejected
+    /// </remarks>
     public async Task<ServiceResult> SetUserRoleAsync(Guid userId, UserRole role)
     {
         var user = await _userManager.Users.FirstOrDefaultAsync(u => u.Id == userId);

--- a/src/PpmV2.Infrastructure/Auth/JwtTokenService.cs
+++ b/src/PpmV2.Infrastructure/Auth/JwtTokenService.cs
@@ -8,6 +8,16 @@ using System.Text;
 
 namespace PpmV2.Infrastructure.Auth;
 
+/// <summary>
+/// Generates JSON Web Tokens (JWT) for authenticated users.
+/// </summary>
+/// <remarks>
+/// This service is part of the Infrastructure layer and is responsible
+/// solely for token creation, not for authentication or authorization logic.
+///
+/// The token contains domain-relevant claims (user id, role, status)
+/// that are later used by the API for authorization decisions.
+/// </remarks>
 public class JwtTokenService : IJwtTokenService
 {
     private readonly IConfiguration _config;
@@ -17,6 +27,15 @@ public class JwtTokenService : IJwtTokenService
         _config = config;
     }
 
+    /// <summary>
+    /// Creates a signed JWT token based on the provided user claims.
+    /// </summary>
+    /// <remarks>
+    /// Security notes:
+    /// - Token settings (issuer, audience, key) are read from configuration.
+    /// - A symmetric signing key (HMAC SHA-256) is used.
+    /// - Token lifetime is intentionally limited.
+    /// </remarks>
     public string GenerateToken(JwtUserClaims claims)
     {
         var jwtSection = _config.GetSection("Jwt");
@@ -27,6 +46,8 @@ public class JwtTokenService : IJwtTokenService
         var signingKey = new SymmetricSecurityKey(Encoding.UTF8.GetBytes(key));
         var creds = new SigningCredentials(signingKey, SecurityAlgorithms.HmacSha256);
 
+        // Claims embedded into the token.
+        // These claims are later evaluated by authorization policies and guards.
         var tokenClaims = new List<Claim>
         {
             new(JwtRegisteredClaimNames.Sub, claims.UserId.ToString()),

--- a/src/PpmV2.Infrastructure/Persistence/AppDbContext.cs
+++ b/src/PpmV2.Infrastructure/Persistence/AppDbContext.cs
@@ -7,35 +7,51 @@ using PpmV2.Infrastructure.Identity;
 
 namespace PpmV2.Infrastructure.Persistence;
 
+
+/// <summary>
+/// Central EF Core DbContext for the application.
+/// </summary>
+/// <remarks>
+/// This DbContext is part of the Infrastructure (Persistence) layer and acts as the persistence boundary.
+/// The application layer should not depend on this DbContext directly, but on repository/query abstractions.
+/// </remarks>
+
+
 public class AppDbContext : IdentityDbContext<AppUser, AppRole, Guid>
 {
     public AppDbContext(DbContextOptions<AppDbContext> options) : base(options)
     {
     }
-
+    /// <summary>Read/write access to user profile data (separate from Identity tables).</summary>
     public DbSet<UserProfile> UserProfiles => Set<UserProfile>();
+
+    /// <summary>Locations where shifts or events can take place.</summary>
     public DbSet<Location> Locations => Set<Location>();
 
+    /// <summary>
+    /// Shifts aggregate set.
+    /// Note: The DbSet name is kept as legacy ("Einsaetze") for compatibility with existing code/migrations.
+    /// </summary>
     public DbSet<Shift> Einsaetze => Set<Shift>();
+
+    /// <summary>Participants assigned to a shift.</summary>
     public DbSet<ShiftParticipant> EinsatzParticipants => Set<ShiftParticipant>();
 
     protected override void OnModelCreating(ModelBuilder builder)
     {
         base.OnModelCreating(builder);
 
+        // Automatically applies all IEntityTypeConfiguration<> mappings from this assembly.
         builder.ApplyConfigurationsFromAssembly(typeof(AppDbContext).Assembly);
 
-        //builder.ApplyConfiguration(new EinsatzConfiguration());
-        //builder.ApplyConfiguration(new EinsatzParticipantConfiguration());
-        //builder.ApplyConfiguration(new LocationConfiguration());
-
-        // AppUser <-> UserProfile 1:1 relation
+        // AppUser <-> UserProfile: 1:1 relationship (Identity user owns exactly one profile record).
         builder.Entity<AppUser>()
             .HasOne(u => u.Profile)
             .WithOne()
             .HasForeignKey<UserProfile>(p => p.IdentityUserId)
             .OnDelete(DeleteBehavior.Cascade);
 
+        // Enforce uniqueness to guarantee the 1:1 mapping at database level.
         builder.Entity<UserProfile>()
             .HasIndex(p => p.IdentityUserId)
             .IsUnique();

--- a/src/PpmV2.Infrastructure/Persistence/Configurations/LocationConfiguration.cs
+++ b/src/PpmV2.Infrastructure/Persistence/Configurations/LocationConfiguration.cs
@@ -4,6 +4,13 @@ using PpmV2.Domain.Locations;
 
 namespace PpmV2.Infrastructure.Persistence.Configurations;
 
+/// <summary>
+/// EF Core configuration for Location.
+/// </summary>
+/// <remarks>
+/// A Location represents a place(Unterkunft) where a Shift/Einsatz or an Event can happen
+/// (e.g., Location accommodation, external activity venue, camp site).
+/// </remarks>
 public sealed class LocationConfiguration : IEntityTypeConfiguration<Location>
 {
     public void Configure(EntityTypeBuilder<Location> builder)
@@ -30,10 +37,10 @@ public sealed class LocationConfiguration : IEntityTypeConfiguration<Location>
 
         builder.Property(x => x.CreatedAt).IsRequired();
 
-        // Prevents duplicates in the same district
+        // Prevent duplicates within the same district (e.g. two entries with identical name + district).
         builder.HasIndex(x => new { x.District, x.Name }).IsUnique();
 
-        // optional for fast filters
+        // Useful for frequent filtering on active/inactive locations.
         builder.HasIndex(x => x.IsActive);
     }
 }

--- a/src/PpmV2.Infrastructure/Persistence/Configurations/ShiftConfiguration.cs
+++ b/src/PpmV2.Infrastructure/Persistence/Configurations/ShiftConfiguration.cs
@@ -5,10 +5,22 @@ using PpmV2.Domain.Shifts;
 
 namespace PpmV2.Infrastructure.Persistence.Configurations;
 
+/// <summary>
+/// EF Core configuration for the Shift aggregate.
+/// </summary>
+/// <remarks>
+/// This configuration defines the persistence mapping for Shifts,
+/// including table mapping, required fields and relationships.
+/// 
+/// Note: The underlying database table name ("Einsaetze") is kept
+/// for compatibility with existing migrations and data.
+/// The refactor from "Einsaetze" to "Shifts" is applied at code level only.
+/// </remarks>
 public class ShiftConfiguration : IEntityTypeConfiguration<Shift>
 {
     public void Configure(EntityTypeBuilder<Shift> builder)
     {
+        // Keep legacy table name to avoid schema-breaking migrations during refactoring.
         builder.ToTable("Einsaetze");
 
         builder.HasKey(e => e.Id);
@@ -25,6 +37,7 @@ public class ShiftConfiguration : IEntityTypeConfiguration<Shift>
 
         builder.Property(e => e.EndAtUtc);
 
+        // Persist enum as int to keep database representation stable.
         builder.Property(e => e.Status)
             .HasConversion<int>()
             .IsRequired();
@@ -32,13 +45,15 @@ public class ShiftConfiguration : IEntityTypeConfiguration<Shift>
         builder.Property(e => e.LocationId)
             .IsRequired();
 
-        // FK -> Locations, ohne Navigation Property
+        // Foreign key to Location without navigation property on Location side.
+        // A Shift always belongs to exactly one Location.
         builder.HasOne<Location>()
             .WithMany()
             .HasForeignKey(e => e.LocationId)
             .OnDelete(DeleteBehavior.Restrict);
 
-        // 1:n Einsatz -> Participants
+        // One-to-many relationship: Shift -> Participants.
+        // Participants are deleted automatically when the owning Shift is deleted.
         builder.HasMany(e => e.Participants)
             .WithOne()
             .HasForeignKey(p => p.EinsatzId)

--- a/src/PpmV2.Infrastructure/Persistence/Configurations/ShiftParticipantConfiguration.cs
+++ b/src/PpmV2.Infrastructure/Persistence/Configurations/ShiftParticipantConfiguration.cs
@@ -4,25 +4,38 @@ using PpmV2.Domain.Shifts;
 
 namespace PpmV2.Infrastructure.Persistence.Configurations;
 
+/// <summary>
+/// EF Core configuration for ShiftParticipant.
+/// </summary>
+/// <remarks>
+/// ShiftParticipant represents the association between a Shift and a User,
+/// including the assigned role within the Shift (e.g. Lead, Member).
+///
+/// This entity acts as a join table with additional domain meaning (role),
+/// therefore it is modeled explicitly instead of using a simple many-to-many mapping.
+/// </remarks>
 public class ShiftParticipantConfiguration : IEntityTypeConfiguration<ShiftParticipant>
 {
     public void Configure(EntityTypeBuilder<ShiftParticipant> builder)
     {
+        // Keep legacy table name for compatibility with existing schema.// Table name
         builder.ToTable("EinsatzParticipants");
 
-        // Composite Key
+        // Composite primary key ensures:
+        // - a user can participate only once per shift
+        // - no surrogate key is required for the join entity
         builder.HasKey(p => new { p.EinsatzId, p.UserId });
 
-        // Enum -> int
+        // Persist role enum as int to keep database representation stable.
         builder.Property(p => p.Role)
             .HasConversion<int>()
             .IsRequired();
 
-        // Indexe (praktisch für Abfragen)
+        // Indexes to support common access patterns.
         builder.HasIndex(p => p.EinsatzId);
         builder.HasIndex(p => p.UserId);
 
-        // optional: häufige Query: "Leader eines Einsatzes"
+        // Optimizes queries such as "find the lead of a given shift".
         builder.HasIndex(p => new { p.EinsatzId, p.Role });
     }
 }

--- a/src/PpmV2.Infrastructure/Persistence/Configurations/UserProfileConfiguration.cs
+++ b/src/PpmV2.Infrastructure/Persistence/Configurations/UserProfileConfiguration.cs
@@ -5,6 +5,13 @@ using PpmV2.Infrastructure.Identity;
 
 namespace PpmV2.Infrastructure.Persistence.Configurations;
 
+/// <summary>
+/// EF Core configuration for the UserProfile entity.
+/// </summary>
+/// <remarks>
+/// UserProfile stores application-specific user data that complements ASP.NET Core Identity.
+/// A 1:1 relationship between AppUser (Identity) and UserProfile is enforced at database level.
+/// </remarks>
 public class UserProfileConfiguration : IEntityTypeConfiguration<UserProfile>
 {
     public void Configure(EntityTypeBuilder<UserProfile> builder)
@@ -17,9 +24,10 @@ public class UserProfileConfiguration : IEntityTypeConfiguration<UserProfile>
         builder.Property(p => p.Lastname).IsRequired();
         builder.Property(p => p.Email).IsRequired();
 
+        // Ensures a single profile record per identity user (1:1).
         builder.HasIndex(p => p.IdentityUserId).IsUnique();
 
-        // AppUser <-> UserProfile 1:1 relation
+        // Identity (AppUser) owns exactly one profile. Deleting the identity user cascades the profile.
         builder.HasOne<AppUser>()
             .WithOne(u => u.Profile)
             .HasForeignKey<UserProfile>(p => p.IdentityUserId)

--- a/src/PpmV2.Infrastructure/Persistence/Queries/LocationQueryService.cs
+++ b/src/PpmV2.Infrastructure/Persistence/Queries/LocationQueryService.cs
@@ -4,6 +4,16 @@ using PpmV2.Application.Locations.Interfaces;
 
 namespace PpmV2.Infrastructure.Persistence.Queries;
 
+/// <summary>
+/// Read-only query service for Locations.
+/// </summary>
+/// <remarks>
+/// This service represents the CQRS read side for Location data.
+/// It is EF Core dependent and therefore located in the Infrastructure/Persistence layer.
+///
+/// The service returns lightweight DTOs optimized for list and selection scenarios
+/// (e.g. dropdowns, filters), not full domain entities.
+/// </remarks>
 public sealed class LocationQueryService : ILocationQueryService
 {
     private readonly AppDbContext _db;
@@ -13,10 +23,13 @@ public sealed class LocationQueryService : ILocationQueryService
         _db = db;
     }
 
+    /// <summary>
+    /// Returns all active locations ordered by district and name.
+    /// </summary>
     public async Task<IReadOnlyList<LocationListItemDto>> GetActiveAsync()
     {
         return await _db.Locations
-            .AsNoTracking()
+            .AsNoTracking() // Read-only query: no change tracking required.
             .Where(l => l.IsActive)
             .OrderBy(l => l.District)
             .ThenBy(l => l.Name)

--- a/src/PpmV2.Infrastructure/Persistence/Repositories/UserProfileRepository.cs
+++ b/src/PpmV2.Infrastructure/Persistence/Repositories/UserProfileRepository.cs
@@ -4,6 +4,14 @@ using PpmV2.Domain.Users;
 
 namespace PpmV2.Infrastructure.Persistence.Repositories;
 
+/// <summary>
+/// EF Core repository for UserProfile entities.
+/// </summary>
+/// <remarks>
+/// UserProfile stores application-specific user data and complements ASP.NET Identity.
+/// This repository encapsulates all persistence operations for profiles and keeps EF Core concerns
+/// out of the application layer.
+/// </remarks>
 public class UserProfileRepository : IUserProfileRepository
 {
     private readonly AppDbContext _dbContext;
@@ -13,12 +21,14 @@ public class UserProfileRepository : IUserProfileRepository
         _dbContext = dbContext;
     }
 
+    /// <summary>Returns a profile by its domain identifier.</summary>
     public async Task<UserProfile?> GetByIdAsync(Guid id)
     {
         return await _dbContext.UserProfiles
             .FirstOrDefaultAsync(u => u.Id == id);
     }
 
+    /// <summary>Returns a profile by the associated Identity user id (1:1 relationship).</summary>
     public async Task<UserProfile?> GetByIdentityUserIdAsync(Guid identityUserId)
     {
         return await _dbContext.UserProfiles


### PR DESCRIPTION
- **Infrastructure/Persistence:** AppDbContext, EF Core Configurations (Shift, ShiftParticipant, Location, UserProfile), Query/Repositories
- **Infrastructure/Auth:** AuthService, JwtTokenService
- **Infrastructure/Admin:** AdminUserService, AdminSeeder
- **API: Controller-Boundaries** (AuthController, AdminUsersController), ApiProblem, ExceptionHandlingMiddleware, Program.cs (Startup/Pipeline/Policies/CORS/Seeding)
- **Application/Shifts + Common:** Commands/DTOs/Ports (IShiftRepository, IShiftDetailsQuery, Create-UseCase), AppError, ValidationException, ServiceResult